### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-xtts"
+description = "a custom comfyui node for [a/coqui-ai/TTS](https://github.com/coqui-ai/TTS.git)'s xtts module! support 17 languages voice cloning and tts"
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["# core deps", "cython>=0.29.30", "scipy>=1.11.2", "soundfile>=0.12.0", "librosa>=0.10.0", "scikit-learn>=1.3.0", "numba==0.55.1;python_version<\"3.9\"", "numba>=0.57.0;python_version>=\"3.9\"", "inflect>=5.6.0", "tqdm>=4.64.1", "anyascii>=0.3.0", "pyyaml>=6.0", "fsspec>=2023.6.0 # <= 2023.9.1 makes aux tests fail", "aiohttp>=3.8.1", "packaging>=23.1", "mutagen==1.47.0", "# deps for examples", "flask>=2.0.1", "# deps for inference", "pysbd>=0.3.4", "# deps for notebooks", "umap-learn>=0.5.1", "pandas>=1.4,<2.0", "# deps for training", "matplotlib>=3.7.0", "# coqui stack", "trainer>=0.0.36", "# config management", "coqpit>=0.0.16", "# chinese g2p deps", "jieba", "pypinyin", "# korean", "hangul_romanize", "# gruut+supported langs", "gruut[de,es,fr]==2.2.3", "# deps for korean", "jamo", "nltk", "g2pkk>=0.1.1", "# deps for bangla", "bangla", "bnnumerizer", "bnunicodenormalizer", "#deps for tortoise", "einops>=0.6.0", "transformers>=4.33.0", "#deps for bark", "encodec>=0.1.1", "# deps for XTTS", "unidecode>=1.3.2", "num2words", "spacy[ja]>=3", "mecab-python3==1.0.6", "unidic-lite==1.0.8", "cutlet", "pydub", "srt", "audiotsm", "numpy"]
+
+[project.urls]
+Repository = "https://github.com/AIFSH/ComfyUI-XTTS"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-XTTS"
+Icon = ""


### PR DESCRIPTION
We are working with dr.lt.data and comfyanon to build a global registry for custom nodes (similar to PyPI). Eventually, the registry will be used as a backend for the UI-manager. All nodes go through a verification process before being published to users.

The main benefits are that authors can
- publish nodes by version and users can safely update nodes knowing ahead of time if their workflows will break or not
- automate testing against new commits in the comfy repo and existing workflows through our CI/CD dashboard

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Check out our [docs](https://docs.comfy.org/registry/overview#introduction) if you want to know more about the registry. Otherwise, feel free to message me on discord at haohao_81202 or join our [server](https://discord.com/invite/comfyorg) if you have any questions!